### PR TITLE
Implementation of OpenTelemetry metrics transport

### DIFF
--- a/.github/workflows/cs-fixer.yml
+++ b/.github/workflows/cs-fixer.yml
@@ -3,7 +3,7 @@ name: CS-Fixer
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '**.php'
   pull_request:

--- a/.github/workflows/cs-fixer.yml
+++ b/.github/workflows/cs-fixer.yml
@@ -1,0 +1,14 @@
+name: CS-Fixer
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.php'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  cs-fixer:
+    uses: shopware/github-actions/.github/workflows/cs-fixer.yml@main

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -7,7 +7,7 @@ on:
       - 'phpstan.neon.dist'
       - 'phpstan-baseline.neon'
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,33 @@
+name: PHPStan
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - 'phpstan.neon.dist'
+      - 'phpstan-baseline.neon'
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  static-analyse:
+    runs-on: ubuntu-latest
+    env:
+      extensions: opentelemetry
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          extensions: ${{ env.extensions }}
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '**.php'
       - 'composer.json'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,52 @@
+name: PHPUnit
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.php'
+      - 'composer.json'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.3"
+        dependencies:
+          - lowest
+          - highest
+    env:
+      extensions: opentelemetry
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+          coverage: xdebug
+          extensions: ${{ env.extensions }}
+
+      - name: Install lowest dependencies with composer
+        if: matrix.dependencies == 'lowest'
+        run: composer update --no-ansi --no-interaction --no-progress --prefer-lowest
+
+      - name: Install highest dependencies with composer
+        if: matrix.dependencies == 'highest'
+        run: composer update --no-ansi --no-interaction --no-progress
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml
+
+      - name: Upload Codecov
+        if: matrix.php-version == '8.3' && matrix.dependencies == 'highest'
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Pipeline of the project is using  https://github.com/shopware/github-actions/blob/main/.github/workflows/cs-fixer.yml
+ *
+ * This file is added to make it easier to run php-cs-fixer during development.
+ *
+ */
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
+return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PER-CS2.0' => true,
+        'no_unused_imports' => true,
+    ])
+    ->setFinder(
+        (new Finder())
+            ->in(__DIR__)
+    )
+    ;

--- a/README.md
+++ b/README.md
@@ -73,3 +73,40 @@ monolog:
             type: service
             id: monolog.handler.open_telemetry
 ```
+
+## Transport metrics to OpenTelemetry
+
+You can enable OpenTelemetry metrics transport with the following configuration:
+
+```yaml
+# config/packages/opentelemetry.yaml
+open_telemetry_shopware:
+  metrics:
+    enabled: true
+    namespace: 'io.opentelemetry.contrib.php.shopware' # or your custom namespace
+```
+
+Please note that OpenTelemetry SDK has to be configured to send metrics to the collector.
+It is configured using the same environment variables. Example configuration could look like this:
+
+```bash
+OTEL_SERVICE_NAME=shopware
+OTEL_PHP_AUTOLOAD_ENABLED=true
+OTEL_METRICS_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
+```
+
+### Temporality configuration
+OpenTelemetry PHP SDK does not support storage for accumulation of metrics. As PHP processes are short-lived, 
+it's best to emit metrics with delta temporality and aggregate them on receiving side. Unfortunately at the moment of writing this
+OpenTelemetry Collector does not support transforming delta temporality metrics to cumulative. The feature is in the
+development, the progress can be tracked [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30705).
+
+Meanwhile the issue can be handled either by implementing aggregation manually or use metrics backend that
+can work with delta temporality. We've successfully tested this with DataDog.
+
+Some links:
+- [OpenTelemetry Metrics Data Model](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points)
+- [Temporality easily explained](https://grafana.com/blog/2023/09/26/opentelemetry-metrics-a-guide-to-delta-vs.-cumulative-temporality-trade-offs/)

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
     },
     "require-dev": {
         "open-telemetry/opentelemetry-logger-monolog": "*",
-        "phpunit/phpunit": "^11.2"
+        "phpunit/phpunit": "^11.2",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-symfony": "^1.4",
+        "phpstan/extension-installer": "^1.4"
     },
     "suggest": {
         "open-telemetry/opentelemetry-logger-monolog": "Monolog logger for OpenTelemetry",
@@ -49,7 +52,8 @@
     "config": {
         "allow-plugins": {
             "php-http/discovery": false,
-            "symfony/runtime": false
+            "symfony/runtime": false,
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "symfony/http-client-contracts": "*"
     },
     "require-dev": {
-        "open-telemetry/opentelemetry-logger-monolog": "*"
+        "open-telemetry/opentelemetry-logger-monolog": "*",
+        "phpunit/phpunit": "^11.2"
     },
     "suggest": {
         "open-telemetry/opentelemetry-logger-monolog": "Monolog logger for OpenTelemetry",
@@ -38,6 +39,12 @@
         "files": [
             "_register.php"
         ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shopware\\OpenTelemetry\\Tests\\Unit\\": "tests/unit/",
+            "Shopware\\OpenTelemetry\\Tests\\Integration\\": "tests/integration/"
+        }
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.1",
         "ext-opentelemetry": "*",
         "monolog/monolog": "2.* || 3.*",
-        "shopware/core": "*",
+        "shopware/core": "6.6.x-dev",
         "open-telemetry/api": "^1.0.0beta10",
         "open-telemetry/sem-conv": "^1.22",
         "symfony/http-kernel": "*",

--- a/docker/.env.dist
+++ b/docker/.env.dist
@@ -1,0 +1,2 @@
+DD_SITE=datadoghq.eu
+DD_API_KEY=<YOU_KEY_HERE>

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -10,6 +10,9 @@ services:
       - "4317:4317"  # otlp grpc
       - "4318:4318"  # otlp http
       - "8889:8889"  # prometheus exporter (accessible by http)
+    environment:
+      DD_SITE: ${DD_SITE}
+      DD_API_KEY: ${DD_API_KEY}
 
   # To eventually offload to Tempo...
   tempo:
@@ -56,6 +59,20 @@ services:
     command: -config.file=/etc/loki/local-config.yaml
     volumes:
       - ./loki.yaml:/etc/loki/local-config.yaml
+
+  dd-agent:
+    container_name: dd-agent
+    environment:
+      - DD_API_KEY=${DD_API_KEY}
+      - DD_SITE=${DD_SITE}
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+      - DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    image: gcr.io/datadoghq/agent:7
 
 volumes:
   tempo-data:

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "4317:4317"  # otlp grpc
       - "4318:4318"  # otlp http
+      - "8889:8889"  # prometheus exporter (accessible by http)
 
   # To eventually offload to Tempo...
   tempo:
@@ -17,7 +18,7 @@ services:
     stop_signal: SIGKILL
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
-      - tempo-data:/tmp/tempo
+      - tempo-data:/var/tempo
     ports:
       - "14268:14268"  # jaeger ingest
       - "3200:3200"   # tempo
@@ -38,6 +39,7 @@ services:
     image: grafana/grafana:latest
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - grafana-data:/var/lib/grafana
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
@@ -57,3 +59,4 @@ services:
 
 volumes:
   tempo-data:
+  grafana-data:

--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -2,15 +2,25 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 exporters:
   logging:
+  debug:
   otlp:
     endpoint: tempo:4317
     tls:
       insecure: true
   loki:
     endpoint: http://loki:3100/loki/api/v1/push
+  prometheus:
+    endpoint: 0.0.0.0:8889
+#    const_labels:
+#      src: shopware
+    send_timestamps: true
+    metric_expiration: 180m
+
 service:
   telemetry:
     logs:
@@ -22,3 +32,6 @@ service:
     logs:
       receivers: [otlp]
       exporters: [loki, logging]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus, debug]

--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -8,18 +8,36 @@ receivers:
 exporters:
   logging:
   debug:
-  otlp:
+  otlp/tempo:
     endpoint: tempo:4317
     tls:
       insecure: true
+  # exporter to datadog agent using otlp protocol
+  # otlp/datadog:
+  #   endpoint: dd-agent:4317
+  #   tls:
+  #     insecure: true
   loki:
     endpoint: http://loki:3100/loki/api/v1/push
   prometheus:
     endpoint: 0.0.0.0:8889
-#    const_labels:
-#      src: shopware
-    send_timestamps: true
+    # adding labels to the metrics
+    # const_labels:
+    #   src: shopware
+    send_timestamps: false
     metric_expiration: 180m
+  # exporter to datadog using datadog api
+  # for configuration example see https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml
+  datadog:
+    api:
+      site: ${env:DD_SITE}
+      key: ${env:DD_API_KEY}
+    metrics:
+      histograms:
+        mode: counters
+        send_aggregation_metrics: true
+    traces:
+      # trace_buffer: 10
 
 service:
   telemetry:
@@ -28,10 +46,14 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlp]
+      # if you want to export through datadog agent, not to api directly, use otlp/datadog instead of datadog
+      # in such case otlp/datadog exporter have to be enabled in exporters section
+      exporters: [otlp/tempo, debug, datadog]
     logs:
       receivers: [otlp]
       exporters: [loki, logging]
     metrics:
       receivers: [otlp]
-      exporters: [prometheus, debug]
+      # if you want to export through datadog agent, not to api directly, use otlp/datadog instead of datadog
+      # in such case otlp/datadog exporter have to be enabled in exporters section
+      exporters: [prometheus, debug, datadog]

--- a/docker/prometheus.yaml
+++ b/docker/prometheus.yaml
@@ -9,3 +9,6 @@ scrape_configs:
   - job_name: 'tempo'
     static_configs:
       - targets: [ 'tempo:3200' ]
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: [ 'otel-collector:8889' ]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,66 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to constant SPAN_KIND_INTERNAL on an unknown class Opentelemetry\\\\Proto\\\\Trace\\\\V1\\\\Span\\\\SpanKind\\.$#"
+			count: 1
+			path: src/Instrumentation/CommandInstrumentation.php
+
+		-
+			message: "#^Access to constant STATUS_CODE_ERROR on an unknown class Opentelemetry\\\\Proto\\\\Trace\\\\V1\\\\Status\\\\StatusCode\\.$#"
+			count: 1
+			path: src/Instrumentation/CommandInstrumentation.php
+
+		-
+			message: "#^Method Shopware\\\\OpenTelemetry\\\\Instrumentation\\\\CommandInstrumentation\\:\\:register\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Instrumentation/CommandInstrumentation.php
+
+		-
+			message: "#^Method Shopware\\\\OpenTelemetry\\\\Instrumentation\\\\ConnectionInstrumentation\\:\\:getBacktrace\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Instrumentation/ConnectionInstrumentation.php
+
+		-
+			message: "#^Parameter \\#1 \\$spanName of method OpenTelemetry\\\\API\\\\Trace\\\\TracerInterface\\:\\:spanBuilder\\(\\) expects non\\-empty\\-string, string given\\.$#"
+			count: 1
+			path: src/Instrumentation/HttpClientInstrumentation.php
+
+		-
+			message: "#^Method Shopware\\\\OpenTelemetry\\\\Instrumentation\\\\RequestPropagationGetter\\:\\:get\\(\\) has parameter \\$carrier with no type specified\\.$#"
+			count: 1
+			path: src/Instrumentation/RequestPropagationGetter.php
+
+		-
+			message: "#^Method Shopware\\\\OpenTelemetry\\\\Instrumentation\\\\RequestPropagationGetter\\:\\:keys\\(\\) has parameter \\$carrier with no type specified\\.$#"
+			count: 1
+			path: src/Instrumentation/RequestPropagationGetter.php
+
+		-
+			message: "#^Parameter \\#1 \\$spanName of method OpenTelemetry\\\\API\\\\Trace\\\\TracerInterface\\:\\:spanBuilder\\(\\) expects non\\-empty\\-string, string given\\.$#"
+			count: 1
+			path: src/Instrumentation/SymfonyInstrumentation.php
+
+		-
+			message: "#^Method Shopware\\\\OpenTelemetry\\\\Messenger\\\\EnvelopePropagator\\:\\:get\\(\\) has parameter \\$carrier with no type specified\\.$#"
+			count: 1
+			path: src/Messenger/EnvelopePropagator.php
+
+		-
+			message: "#^Method Shopware\\\\OpenTelemetry\\\\Messenger\\\\EnvelopePropagator\\:\\:keys\\(\\) has parameter \\$carrier with no type specified\\.$#"
+			count: 1
+			path: src/Messenger/EnvelopePropagator.php
+
+		-
+			message: "#^Method Shopware\\\\OpenTelemetry\\\\Messenger\\\\EnvelopeStamp\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Messenger/EnvelopeStamp.php
+
+		-
+			message: "#^Access to constant SPAN_KIND_CONSUMER on an unknown class Opentelemetry\\\\Proto\\\\Trace\\\\V1\\\\Span\\\\SpanKind\\.$#"
+			count: 1
+			path: src/Messenger/MessageBusSubscriber.php
+
+		-
+			message: "#^Method Shopware\\\\OpenTelemetry\\\\Messenger\\\\MessageBusSubscriber\\:\\:onHandled\\(\\) has parameter \\$event with no type specified\\.$#"
+			count: 1
+			path: src/Messenger/MessageBusSubscriber.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,9 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     phpVersion: 80100
     level: max
     paths:
         - src
-    ignoreErrors:
-        # Remove when 6.6 is released
-        - '#Shopware\\Core\\Framework\\Adapter\\Kernel\\HttpKernel#'
+        - tests

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="true"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="Unit Test Suite">
+            <directory>tests/unit</directory>
+        </testsuite>
+        <testsuite name="Integration Test Suite">
+            <directory>tests/integration</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Instrumentation/CommandInstrumentation.php
+++ b/src/Instrumentation/CommandInstrumentation.php
@@ -10,6 +10,7 @@ use Opentelemetry\Proto\Trace\V1\Status\StatusCode;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Symfony\Component\Console\Application;
 use Throwable;
+
 use function OpenTelemetry\Instrumentation\hook;
 
 class CommandInstrumentation
@@ -48,7 +49,7 @@ class CommandInstrumentation
                 Application $application,
                 array       $params,
                 mixed       $ret,
-                ?Throwable  $exception
+                ?Throwable  $exception,
             ) {
                 $scope = Context::storage()->scope();
                 if (null === $scope) {
@@ -60,7 +61,7 @@ class CommandInstrumentation
                     $span->setStatus(StatusCode::STATUS_CODE_ERROR, $exception->getMessage());
                 }
                 $span->end();
-            }
+            },
         );
     }
 }

--- a/src/Instrumentation/ConnectionInstrumentation.php
+++ b/src/Instrumentation/ConnectionInstrumentation.php
@@ -56,11 +56,11 @@ final class ConnectionInstrumentation
 
                 if ($part === 'SELECT' && preg_match('/FROM\s*`?(\w*)`?/m', $query, $matches)) {
                     $spanTitle .= '.' . $matches[1];
-                } else if ($part === 'INSERT' && preg_match('/INTO\s*`?(\w*)`?/m', $query, $matches)) {
+                } elseif ($part === 'INSERT' && preg_match('/INTO\s*`?(\w*)`?/m', $query, $matches)) {
                     $spanTitle .= '.' . $matches[1];
-                } else if ($part === 'UPDATE' && preg_match('/UPDATE\s*`?(\w*)`?/m', $query, $matches)) {
+                } elseif ($part === 'UPDATE' && preg_match('/UPDATE\s*`?(\w*)`?/m', $query, $matches)) {
                     $spanTitle .= '.' . $matches[1];
-                } else if ($part === 'DELETE' && preg_match('/FROM\s*`?(\w*)`?/m', $query, $matches)) {
+                } elseif ($part === 'DELETE' && preg_match('/FROM\s*`?(\w*)`?/m', $query, $matches)) {
                     $spanTitle .= '.' . $matches[1];
                 }
 
@@ -86,7 +86,7 @@ final class ConnectionInstrumentation
                 Statement $repository,
                 array $params,
                 mixed $ret,
-                ?Throwable $exception
+                ?Throwable $exception,
             ) {
                 $scope = Context::storage()->scope();
                 if (null === $scope) {
@@ -100,7 +100,7 @@ final class ConnectionInstrumentation
                 }
 
                 $span->end();
-            }
+            },
         );
     }
 
@@ -110,10 +110,10 @@ final class ConnectionInstrumentation
 
         foreach ($backtrace as $trace) {
             if (isset($trace['class']) && (
-                    str_starts_with($trace['class'], 'Doctrine\\DBAL') ||
+                str_starts_with($trace['class'], 'Doctrine\\DBAL') ||
                     str_starts_with($trace['class'], 'Shopware\\OpenTelemetry\\') ||
                     str_starts_with($trace['class'], 'Shopware\Core\Framework\DataAbstractionLayer')
-                )) {
+            )) {
                 continue;
             }
 

--- a/src/Instrumentation/DALInstrumentation.php
+++ b/src/Instrumentation/DALInstrumentation.php
@@ -50,7 +50,7 @@ final class DALInstrumentation
                 EntityRepository $repository,
                 array $params,
                 ?EntitySearchResult $response,
-                ?\Throwable $exception
+                ?\Throwable $exception,
             ) {
                 $scope = Context::storage()->scope();
                 if (null === $scope) {
@@ -64,7 +64,7 @@ final class DALInstrumentation
                 }
 
                 $span->end();
-            }
+            },
         );
 
         hook(
@@ -99,7 +99,7 @@ final class DALInstrumentation
                 EntityRepository $repository,
                 array $params,
                 ?AggregationResultCollection $response,
-                ?\Throwable $exception
+                ?\Throwable $exception,
             ) {
                 $scope = Context::storage()->scope();
                 if (null === $scope) {
@@ -113,7 +113,7 @@ final class DALInstrumentation
                 }
 
                 $span->end();
-            }
+            },
         );
     }
 }

--- a/src/Instrumentation/HttpClientInstrumentation.php
+++ b/src/Instrumentation/HttpClientInstrumentation.php
@@ -93,7 +93,7 @@ final class HttpClientInstrumentation
                 HttpClientInterface $client,
                 array $params,
                 ?ResponseInterface $response,
-                ?\Throwable $exception
+                ?\Throwable $exception,
             ): void {
                 $scope = Context::storage()->scope();
                 if (null === $scope) {

--- a/src/Instrumentation/SymfonyInstrumentation.php
+++ b/src/Instrumentation/SymfonyInstrumentation.php
@@ -72,7 +72,7 @@ final class SymfonyInstrumentation
                 HttpKernel $kernel,
                 array $params,
                 ?Response $response,
-                ?Throwable $exception
+                ?Throwable $exception,
             ): void {
                 $scope = Context::storage()->scope();
                 if (null === $scope) {
@@ -127,7 +127,7 @@ final class SymfonyInstrumentation
                 }
 
                 $span->end();
-            }
+            },
         );
     }
 }

--- a/src/Messenger/EnvelopePropagator.php
+++ b/src/Messenger/EnvelopePropagator.php
@@ -4,6 +4,7 @@ namespace Shopware\OpenTelemetry\Messenger;
 
 use OpenTelemetry\Context\Propagation\PropagationGetterInterface;
 use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
+
 use function assert;
 
 class EnvelopePropagator implements PropagationSetterInterface, PropagationGetterInterface

--- a/src/Messenger/EnvelopeStamp.php
+++ b/src/Messenger/EnvelopeStamp.php
@@ -6,8 +6,5 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 
 class EnvelopeStamp implements StampInterface
 {
-    public function __construct(public array $data = [])
-    {
-
-    }
+    public function __construct(public array $data = []) {}
 }

--- a/src/Metrics/Transports/OpenTelemetryMeterFactory.php
+++ b/src/Metrics/Transports/OpenTelemetryMeterFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\OpenTelemetry\Metrics\Transports;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Metrics\MeterInterface;
+
+/**
+ * @internal
+ */
+class OpenTelemetryMeterFactory
+{
+    public static function createMeter(string $namespace): MeterInterface
+    {
+        return Globals::meterProvider()->getMeter($namespace);
+    }
+}

--- a/src/Metrics/Transports/OpenTelemetryMetricTransport.php
+++ b/src/Metrics/Transports/OpenTelemetryMetricTransport.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\OpenTelemetry\Metrics\Transports;
+
+use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\API\Metrics\ObserverInterface;
+use OpenTelemetry\Context\ContextInterface;
+use Shopware\Core\Framework\Telemetry\TelemetryException;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\Counter;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\Gauge;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\Histogram;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\MetricInterface;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\UpDownCounter;
+use Shopware\Core\Framework\Telemetry\Metrics\MetricTransportInterface;
+
+/**
+ * @phpstan-type Attributes iterable<non-empty-string, string|bool|float|int>
+ */
+class OpenTelemetryMetricTransport implements MetricTransportInterface
+{
+    public function __construct(
+        private string $namespace,
+        private MeterInterface $meter,
+    ) {}
+
+    public function emit(MetricInterface $metric): void
+    {
+        $attributes = [];
+        $context = null;
+
+        match (true) {
+            $metric instanceof UpDownCounter => $this->handleUpDownCounter($metric, $attributes, $context),
+            $metric instanceof Counter => $this->handleCounter($metric, $attributes, $context),
+            $metric instanceof Histogram => $this->handleHistogram($metric, $attributes, $context),
+            $metric instanceof Gauge => $this->handleGauge($metric, $attributes, $context),
+            default => throw TelemetryException::metricNotSupported($metric, $this),
+        };
+    }
+
+    private function formatName(string $name): string
+    {
+        return sprintf('%s.%s', $this->namespace, $name);
+    }
+
+    /**
+     * @param Attributes $attributes
+     */
+    public function handleCounter(Counter $metric, iterable $attributes, ?ContextInterface $context): void
+    {
+        $this->meter
+            ->createCounter(
+                $this->formatName($metric->name),
+                $metric->unit,
+                $metric->description,
+            )->add($metric->value, $attributes, $context);
+    }
+
+    /**
+     * @param Attributes $attributes
+     */
+    public function handleUpDownCounter(UpDownCounter $metric, iterable $attributes, ?ContextInterface $context): void
+    {
+        $this->meter
+            ->createUpDownCounter(
+                $this->formatName($metric->name),
+                $metric->unit,
+                $metric->description,
+            )->add($metric->value, $attributes, $context);
+    }
+
+    /**
+     * @param Attributes $attributes
+     */
+    public function handleHistogram(Histogram $metric, iterable $attributes, ?ContextInterface $context): void
+    {
+        $this->meter
+            ->createHistogram(
+                $this->formatName($metric->name),
+                $metric->unit,
+                $metric->description,
+            )->record($metric->value, $attributes, $context);
+    }
+
+    /**
+     * @param Attributes $attributes
+     */
+    public function handleGauge(Gauge $metric, iterable $attributes, ?ContextInterface $context): void
+    {
+        // todo: replace implementation with sync gauge as soon as it's released in SDK
+        $this->meter
+            ->createObservableGauge(
+                $this->formatName($metric->name),
+                $metric->unit,
+                $metric->description,
+            )->observe(
+                fn(ObserverInterface $observer) => $observer->observe($metric->value, $attributes),
+            );
+    }
+}

--- a/src/OpenTelemetryShopwareBundle.php
+++ b/src/OpenTelemetryShopwareBundle.php
@@ -2,15 +2,25 @@
 
 namespace Shopware\OpenTelemetry;
 
-use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Metrics\MeterInterface;
 use Shopware\OpenTelemetry\Logging\OpenTelemetryLoggerFactory;
 use Shopware\OpenTelemetry\Messenger\MessageBusSubscriber;
+use Shopware\OpenTelemetry\Metrics\Transports\OpenTelemetryMeterFactory;
+use Shopware\OpenTelemetry\Metrics\Transports\OpenTelemetryMetricTransport;
 use Shopware\OpenTelemetry\Profiler\OtelProfiler;
 use OpenTelemetry\Contrib\Logs\Monolog\Handler;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
-class OpenTelemetryShopwareBundle extends Bundle
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+/**
+ * @phpstan-type Config array{metrics: array{enabled: bool, namespace: string}}
+ */
+class OpenTelemetryShopwareBundle extends AbstractBundle
 {
     public function build(ContainerBuilder $container)
     {
@@ -26,6 +36,50 @@ class OpenTelemetryShopwareBundle extends Bundle
             $container
                 ->register('monolog.handler.open_telemetry', Handler::class)
                 ->setFactory([OpenTelemetryLoggerFactory::class, 'build']);
+        }
+
+    }
+
+    public function configure(DefinitionConfigurator $definition): void
+    {
+        $rootNode = $definition->rootNode();
+        \assert($rootNode instanceof ArrayNodeDefinition);
+
+        $rootNode
+            ->children()
+                ->arrayNode('metrics')
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->defaultFalse()
+                        ->end()
+                        ->scalarNode('namespace')
+                            ->defaultValue('io.opentelemetry.contrib.php.shopware')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * @param Config $config
+     */
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $metricsConfig = $config['metrics'];
+        $namespace = $metricsConfig['namespace'];
+
+        if ($metricsConfig['enabled']) {
+            $container->services()
+                ->set(MeterInterface::class)
+                ->factory([OpenTelemetryMeterFactory::class, 'createMeter'])
+                ->arg('$namespace', $namespace);
+
+            $container->services()
+                ->set(OpenTelemetryMetricTransport::class)
+                ->arg('$meter', service(MeterInterface::class))
+                ->arg('$namespace', $namespace)
+                ->tag('shopware.metric_transport');
         }
     }
 }

--- a/tests/integration/OpenTelemetryMeterFactoryTest.php
+++ b/tests/integration/OpenTelemetryMeterFactoryTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Shopware\OpenTelemetry\Tests\Integration;
+
+use OpenTelemetry\API\Metrics\MeterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\OpenTelemetry\Metrics\Transports\OpenTelemetryMeterFactory;
+
+#[CoversClass(OpenTelemetryMeterFactory::class)]
+class OpenTelemetryMeterFactoryTest extends TestCase
+{
+    public function testCreateMeter(): void
+    {
+        $meter = OpenTelemetryMeterFactory::createMeter('test.namespace');
+        $this->assertInstanceOf(MeterInterface::class, $meter);
+    }
+}

--- a/tests/integration/OpenTelemetryShopwareBundleTest.php
+++ b/tests/integration/OpenTelemetryShopwareBundleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Shopware\OpenTelemetry\Tests\Integration;
+
+use OpenTelemetry\API\Metrics\MeterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\OpenTelemetry\Metrics\Transports\OpenTelemetryMetricTransport;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Shopware\OpenTelemetry\OpenTelemetryShopwareBundle;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+/**
+ * @phpstan-import-type Config from OpenTelemetryShopwareBundle
+ */
+#[CoversClass(OpenTelemetryShopwareBundle::class)]
+class OpenTelemetryShopwareBundleTest extends TestCase
+{
+    public function testServicesLoadedWhenMetricsEnabled(): void
+    {
+        $config = ['metrics' => ['enabled' => true, 'namespace' => 'io.opentelemetry.contrib.php.shopware']];
+        $container = $this->loadBundleWithConfig($config);
+
+        $this->assertTrue($container->has(MeterInterface::class));
+        $this->assertTrue($container->has(OpenTelemetryMetricTransport::class));
+    }
+
+    public function testServicesNotLoadedWhenMetricsDisabled(): void
+    {
+        $config = ['metrics' => ['enabled' => false, 'namespace' => 'io.opentelemetry.contrib.php.shopware']];
+        $container = $this->loadBundleWithConfig($config);
+
+        $this->assertFalse($container->has(MeterInterface::class));
+        $this->assertFalse($container->has(OpenTelemetryMetricTransport::class));
+    }
+
+    /**
+     * @param Config $config
+     */
+    private function loadBundleWithConfig(array $config): ContainerBuilder
+    {
+        $bundle = new OpenTelemetryShopwareBundle();
+        $builder = new ContainerBuilder();
+        $fileLocator = new FileLocator(__DIR__);
+        $phpFileLoader = new PhpFileLoader($builder, $fileLocator);
+        $instanceof = [];
+        $configurator = new ContainerConfigurator($builder, $phpFileLoader, $instanceof, __DIR__, __DIR__);
+
+        $bundle->loadExtension($config, $configurator, $builder);
+
+        return $builder;
+    }
+}

--- a/tests/unit/OpenTelemetryMetricTransportTest.php
+++ b/tests/unit/OpenTelemetryMetricTransportTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Shopware\OpenTelemetry\Tests\Unit;
+
+use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\API\Metrics\ObservableGaugeInterface;
+use OpenTelemetry\API\Metrics\ObserverInterface;
+use OpenTelemetry\API\Metrics\UpDownCounterInterface;
+use OpenTelemetry\Context\ContextInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Telemetry\Metrics\Exception\MetricNotSupportedException;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\Counter;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\Gauge;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\Histogram;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\MetricInterface;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\UpDownCounter;
+use Shopware\OpenTelemetry\Metrics\Transports\OpenTelemetryMetricTransport;
+
+/**
+ * @phpstan-import-type Attributes from OpenTelemetryMetricTransport
+ */
+#[CoversClass(OpenTelemetryMetricTransport::class)]
+class OpenTelemetryMetricTransportTest extends TestCase
+{
+    /**
+     * @var MeterInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $meterMock;
+
+    /**
+     * @var ContextInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $contextMock;
+
+    public function setUp(): void
+    {
+        $this->meterMock = $this->createMock(MeterInterface::class);
+        $this->contextMock = $this->createMock(ContextInterface::class);
+    }
+
+    /**
+     * @return array<string, array{metric: MetricInterface, name: string, value: int|float, description: string|null, unit: string|null}>
+     */
+    public static function getMetrics(): array
+    {
+        return [
+            'Counter' => [
+                'metric' => new Counter('cnt', 1, 'desc', 'count'),
+                'name' => 'cnt',
+                'value' => 1,
+                'description' => 'desc',
+                'unit' => 'count',
+            ],
+            'UpDowncounter' => [
+                'metric' => new UpDownCounter('udc', 10, 'ud cnt', null),
+                'name' => 'udc',
+                'value' => 10,
+                'description' => 'ud cnt',
+                'unit' => null,
+            ],
+            'Histogram' => [
+                'metric' => new Histogram('hist', 100, 'histogram', 'ms'),
+                'name' => 'hist',
+                'value' => 100,
+                'description' => 'histogram',
+                'unit' => 'ms',
+            ],
+            'Gauge' => [
+                'metric' => new Gauge('gauge', 11, 'Number of megabytes', 'MB'),
+                'name' => 'gauge',
+                'value' => 11,
+                'description' => 'Number of megabytes',
+                'unit' => 'MB',
+            ],
+        ];
+    }
+
+    public function testEmitUnsupported(): void
+    {
+        $this->expectException(MetricNotSupportedException::class);
+        $transport = new OpenTelemetryMetricTransport('test.namespace', $this->createMock(MeterInterface::class));
+        $transport->emit($this->createMock(MetricInterface::class));
+    }
+
+    #[DataProvider('getMetrics')]
+    public function testEmit(MetricInterface $metric, string $name, int|float $value, ?string $description, ?string $unit): void
+    {
+        $namespace = 'com.shopware.opentelemetry';
+
+        match (true) {
+            $metric instanceof UpDownCounter => $this->expectsUpDownCounter($this->meterMock, null, $namespace, $name, $value, $description, $unit, []),
+            $metric instanceof Counter => $this->expectsCounter($this->meterMock, null, $namespace, $name, $value, $description, $unit, []),
+            $metric instanceof Histogram => $this->expectsHistogram($this->meterMock, null, $namespace, $name, $value, $description, $unit, []),
+            $metric instanceof Gauge => $this->expectsGauge($this->meterMock, null, $namespace, $name, $value, $description, $unit, []),
+            default => self::fail('Data provider returned unsupported metric type'),
+        };
+
+        (new OpenTelemetryMetricTransport($namespace, $this->meterMock))->emit($metric);
+    }
+
+    public function testHandleCounter(): void
+    {
+        $attributes = ['attribute' => 'value'];
+
+        $this->expectsCounter($this->meterMock, $this->contextMock, 'test.namespace', 'test_counter', 3, 'description', 'unit', $attributes);
+
+        $metric = new Counter('test_counter', 3, 'description', 'unit');
+        (new OpenTelemetryMetricTransport('test.namespace', $this->meterMock))->handleCounter($metric, $attributes, $this->contextMock);
+    }
+
+    public function testHandleUpDownCounter(): void
+    {
+        $attributes = ['hostname' => 'api'];
+        $this->expectsUpDownCounter($this->meterMock, $this->contextMock, 'other.namespace', 'test_up_down_counter', -5, 'up down counter with negative value', 'meters', $attributes);
+
+        $metric = new UpDownCounter('test_up_down_counter', -5, 'up down counter with negative value', 'meters');
+        (new OpenTelemetryMetricTransport('other.namespace', $this->meterMock))->handleUpDownCounter($metric, $attributes, $this->contextMock);
+    }
+
+    public function testHandleHistogram(): void
+    {
+        $attributes = [];
+        $this->expectsHistogram($this->meterMock, $this->contextMock, 'other.namespace', 'test_histogram', 300, null, null, $attributes);
+
+        $metric = new Histogram('test_histogram', 300);
+        (new OpenTelemetryMetricTransport('other.namespace', $this->meterMock))->handleHistogram($metric, $attributes, $this->contextMock);
+    }
+
+    public function testHandleGauge(): void
+    {
+        $attributes = ['attribute' => 'value'];
+        $this->expectsGauge($this->meterMock, $this->contextMock, 'my.gauge.namespace', 'test_gauge', 42, 'Number of megabytes', 'MB', $attributes);
+
+        $metric = new Gauge('test_gauge', 42, 'Number of megabytes', 'MB');
+        (new OpenTelemetryMetricTransport('my.gauge.namespace', $this->meterMock))->handleGauge($metric, $attributes, $this->contextMock);
+    }
+
+    /**
+     * @param Attributes $attributes
+     */
+    private function expectsCounter(MockObject $meter, ?MockObject $context, string $namespace, string $metricName, float|int $value, ?string $description, ?string $unit, iterable $attributes): void
+    {
+        $counter = $this->createMock(CounterInterface::class);
+
+        $meter->expects(static::once())
+            ->method('createCounter')
+            ->with(\sprintf("%s.%s", $namespace, $metricName), $unit, $description)
+            ->willReturn($counter);
+
+        $counter->expects(static::once())
+            ->method('add')
+            ->with($value, $attributes, $context);
+    }
+
+    /**
+     * @param Attributes $attributes
+     */
+    private function expectsUpDownCounter(MockObject $meter, ?MockObject $context, string $namespace, string $metricName, float|int $value, ?string $description, ?string $unit, iterable $attributes): void
+    {
+        $upDownCounter = $this->createMock(UpDownCounterInterface::class);
+
+        $meter->expects(static::once())
+            ->method('createUpDownCounter')
+            ->with(\sprintf("%s.%s", $namespace, $metricName), $unit, $description)
+            ->willReturn($upDownCounter);
+
+        $upDownCounter->expects(static::once())
+            ->method('add')
+            ->with($value, $attributes, $context);
+
+    }
+
+    /**
+     * @param Attributes $attributes
+     */
+    private function expectsHistogram(MockObject $meter, ?MockObject $context, string $namespace, string $metricName, float|int $value, ?string $description, ?string $unit, iterable $attributes): void
+    {
+        $histogram = $this->createMock(HistogramInterface::class);
+
+        $meter->expects(static::once())
+            ->method('createHistogram')
+            ->with(\sprintf("%s.%s", $namespace, $metricName), $unit, $description)
+            ->willReturn($histogram);
+
+        $histogram->expects(static::once())
+            ->method('record')
+            ->with($value, $attributes, $context);
+
+    }
+
+    /**
+     * @param Attributes $attributes
+     */
+    private function expectsGauge(MockObject $meter, ?MockObject $context, string $namespace, string $metricName, float|int $value, ?string $description, ?string $unit, iterable $attributes): void
+    {
+        $gauge = $this->createMock(ObservableGaugeInterface::class);
+
+        $meter->expects(static::once())
+            ->method('createObservableGauge')
+            ->with(\sprintf("%s.%s", $namespace, $metricName), $unit, $description)
+            ->willReturn($gauge);
+
+        $observer = $this->createMock(ObserverInterface::class);
+
+        $gauge->expects(static::once())
+            ->method('observe')
+            ->with(static::callback(function ($callback) use ($observer) {
+                $callback($observer);
+                return true;
+            }));
+
+        $observer->expects(static::once())
+            ->method('observe')
+            ->with($value, $attributes);
+    }
+}


### PR DESCRIPTION
# OpenTelemetry transport implementation

This pull request introduces several enhancements and configurations to support metrics collection and reporting within the OpenTelemetry repository.  

## Changes

1. Changed docker setup to support metrics:  
- Added volume for Grafana data.
- Configured otel-collector to listen on all hosts.
- Added debugging exporter.
- Added Prometheus exporter.
- Configured metrics workflow.
- Configured Prometheus to collect data from otel-collector.
- Changed Tempo volume mapping for updated path in the new image version.
- Added Datadog Export to otel-collector Configuration:  
- Configured Datadog agent.
- Added forwarding of metrics to Datadog agent (commented).
- Added forwarding of metrics directly to Datadog API.

2. Added OpenTelemetry Transport for Metrics:
- Implemented a new transport for handling metrics using OpenTelemetry.
- Added basic configuration to make possible enabling/disabling the transport and setting the metrics namespace.

3. Added OpenTelemetry Metric Tests:
- Added phpunit as a dependency.
- Configured two test suites: unit and integration.
- Added basic tests for metrics transport.
