### PR TITLE
Improve instrumentation: add event dispatcher and fix distributed tracing

### DIFF
--- a/src/Instrumentation/ShopwareInstrumentation.php
+++ b/src/Instrumentation/ShopwareInstrumentation.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Shopware\OpenTelemetry\Instrumentation;
 
+use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
@@ -13,6 +15,7 @@ use OpenTelemetry\SemConv\TraceAttributes;
 use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Kernel;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Throwable;
 
@@ -173,27 +176,46 @@ class ShopwareInstrumentation
                     ->setAttribute(TraceAttributes::CODE_LINENO, $lineno);
 
                 $parent = Context::getCurrent();
-                $span = $builder->startSpan();
+                if ($request) {
+                    $parent = Globals::propagator()->extract($request, RequestPropagationGetter::instance());
+                    $span = $builder
+                        ->setParent($parent)
+                        ->setAttribute(TraceAttributes::URL_FULL, $request->getUri())
+                        ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
+                        ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->headers->get('Content-Length'))
+                        ->setAttribute(TraceAttributes::URL_SCHEME, $request->getScheme())
+                        ->setAttribute(TraceAttributes::URL_PATH, $request->getPathInfo())
+                        ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->headers->get('User-Agent'))
+                        ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getHost())
+                        ->setAttribute(TraceAttributes::SERVER_PORT, $request->getPort())
+                        ->startSpan();
+                    $request->attributes->set(SpanInterface::class, $span);
+                } else {
+                    $span = $builder->startSpan();
+                }
 
                 Context::storage()->attach($span->storeInContext($parent));
+                return [$request];
             },
             post: static function (
                 Kernel     $kernel,
-                array      $params,
-                mixed      $ret,
+                array $params,
+                ?Response $response,
                 ?Throwable $exception,
             ) {
                 $scope = Context::storage()->scope();
                 if (null === $scope) {
                     return;
                 }
+                $scope->detach();
                 $span = Span::fromContext($scope->context());
+
                 if ($exception !== null) {
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                     $span->recordException($exception);
                 }
+
                 $span->end();
-                $scope->detach();
             },
         );
     }

--- a/src/Instrumentation/SymfonyInstrumentation.php
+++ b/src/Instrumentation/SymfonyInstrumentation.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Shopware\OpenTelemetry\Instrumentation;
 
-use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Trace\Span;
-use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
@@ -26,17 +24,22 @@ final class SymfonyInstrumentation
 {
     public static function register(): void
     {
+        self::instrumentKernel();
+    }
+
+    private static function instrumentKernel(): void
+    {
         hook(
             HttpKernel::class,
             'handle',
             pre: static function (
                 HttpKernel $kernel,
-                array $params,
-                string $class,
-                string $function,
-                ?string $filename,
-                ?int $lineno,
-            ): array {
+                array      $params,
+                string     $class,
+                string     $function,
+                ?string    $filename,
+                ?int       $lineno,
+            ) {
                 $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.symfony');
                 $request = ($params[0] instanceof Request) ? $params[0] : null;
                 $type = $params[1] ?? HttpKernelInterface::MAIN_REQUEST;
@@ -62,31 +65,14 @@ final class SymfonyInstrumentation
                     ->setAttribute(TraceAttributes::CODE_LINENO, $lineno);
 
                 $parent = Context::getCurrent();
-                if ($request) {
-                    $parent = Globals::propagator()->extract($request, RequestPropagationGetter::instance());
-                    $span = $builder
-                        ->setParent($parent)
-                        ->setAttribute(TraceAttributes::URL_FULL, $request->getUri())
-                        ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
-                        ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->headers->get('Content-Length'))
-                        ->setAttribute(TraceAttributes::URL_SCHEME, $request->getScheme())
-                        ->setAttribute(TraceAttributes::URL_PATH, $request->getPathInfo())
-                        ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->headers->get('User-Agent'))
-                        ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getHost())
-                        ->setAttribute(TraceAttributes::SERVER_PORT, $request->getPort())
-                        ->startSpan();
-                    $request->attributes->set(SpanInterface::class, $span);
-                } else {
-                    $span = $builder->startSpan();
-                }
-                Context::storage()->attach($span->storeInContext($parent));
 
-                return [$request];
+                $span = $builder->setParent($parent)->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (
                 HttpKernel $kernel,
-                array $params,
-                ?Response $response,
+                array      $params,
+                ?Response  $response,
                 ?Throwable $exception,
             ): void {
                 $scope = Context::storage()->scope();
@@ -156,11 +142,11 @@ final class SymfonyInstrumentation
             'handleThrowable',
             pre: static function (
                 HttpKernel $kernel,
-                array $params,
-                string $class,
-                string $function,
-                ?string $filename,
-                ?int $lineno,
+                array      $params,
+                string     $class,
+                string     $function,
+                ?string    $filename,
+                ?int       $lineno,
             ): array {
                 /** @var \Throwable $throwable */
                 $throwable = $params[0];

--- a/src/Instrumentation/SymfonyInstrumentation.php
+++ b/src/Instrumentation/SymfonyInstrumentation.php
@@ -10,6 +10,7 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
 use Shopware\Core\Framework\Adapter\Kernel\HttpKernel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Throwable;
 use OpenTelemetry\SemConv\TraceAttributes;
@@ -25,6 +26,7 @@ final class SymfonyInstrumentation
     public static function register(): void
     {
         self::instrumentKernel();
+        self::instrumentEventDispatcher();
     }
 
     private static function instrumentKernel(): void
@@ -158,6 +160,60 @@ final class SymfonyInstrumentation
                     ->setStatus(StatusCode::STATUS_ERROR, $throwable->getMessage());
 
                 return $params;
+            },
+        );
+    }
+
+    private static function instrumentEventDispatcher(): void
+    {
+        hook(
+            EventDispatcher::class,
+            'dispatch',
+            pre: static function (
+                EventDispatcher $dispatcher,
+                array           $params,
+                string          $class,
+                string          $function,
+                ?string         $filename,
+                ?int            $lineno,
+            ) {
+                $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.symfony');
+                $eventClass = $params[0]::class;
+                $name = sprintf('EventDispatcher::dispatch(%s)', $eventClass);
+
+                $builder = $instrumentation
+                    ->tracer()
+                    ->spanBuilder($name)
+                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINENO, $lineno)
+                    ->setAttribute(TraceAttributes::EVENT_NAME, $eventClass);
+
+                $parent = Context::getCurrent();
+                $span = $builder->setParent($parent)->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
+            },
+            post: static function (
+                EventDispatcher $dispatcher,
+                array           $params,
+                object         $return,
+                ?\Throwable     $exception,
+            ) {
+                $scope = Context::storage()->scope();
+                if (null === $scope) {
+                    return;
+                }
+                $scope->detach();
+                $span = Span::fromContext($scope->context());
+
+                if ($exception !== null) {
+                    $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+                    $span->recordException($exception);
+                }
+
+                $span->end();
             },
         );
     }


### PR DESCRIPTION
This PR changes two things:

- Moves the handling of distributed headers to the 'Core' Shopware kernel
- Adds additional EventDispatcher tracing

Context:

The parent of the Span is set according to the distributed headers, when it is set under the internal Http Kernel, then the parent/child relationship is messed up and ignored.  The first call to the application, is the Core Kernel `handle`, so this essentially moves the Span one step up