### PR TITLE
fix: update event dispatcher signature

### DIFF
--- a/src/Instrumentation/SymfonyInstrumentation.php
+++ b/src/Instrumentation/SymfonyInstrumentation.php
@@ -198,7 +198,7 @@ final class SymfonyInstrumentation
             post: static function (
                 EventDispatcher $dispatcher,
                 array           $params,
-                object         $return,
+                ?object         $return,
                 ?\Throwable     $exception,
             ) {
                 $scope = Context::storage()->scope();


### PR DESCRIPTION
In case of a function never returning, (i.e. throw exception), the hook signature for the 'return' object can deviate from the interface itself.

This adds the missing nullability for the event-dispatcher hook signature.